### PR TITLE
Show a link to obtain access token; resolves #13

### DIFF
--- a/pocket_cli/cli.py
+++ b/pocket_cli/cli.py
@@ -61,6 +61,8 @@ def configure(consumer_key, sort_field, words_per_minute):
 
     print('You will have to authorize the application to access your articles')
     print('Enter any key once you\'re redirected to google.com')
+    print('Or open this link in browser manually:')
+    print(url);
     webbrowser.open_new_tab(url)
     input()
 


### PR DESCRIPTION
This commit adds printing access token link to provide ability to copy & visit it manually to obtain an access token, as a fallback